### PR TITLE
Fix remote command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ git remote -v
 git remote rm origin
    ```
 
-   `git remove -v` again will now return nothing.
+   `git remote -v` again will now return nothing.
 
 0. Copy a folder name you want to move to your invisible clipboard
    (directory 1).


### PR DESCRIPTION
## Summary
- fix typo in README documentation where `git remove -v` was listed instead of `git remote -v`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68642f26a6688327a7ac3c6d6defd27a